### PR TITLE
Don't bring in Microsoft.EntityFrameworkCore.Design

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Tools/Microsoft.EntityFrameworkCore.Tools.nuspec
+++ b/src/Microsoft.EntityFrameworkCore.Tools/Microsoft.EntityFrameworkCore.Tools.nuspec
@@ -10,16 +10,6 @@
     <description>Visual Studio commands for Entity Framework Core. Includes the Scaffold-DbContext, Add-Migration, and Update-Database commands for the Package Manager Console in Visual Studio.</description>
     <tags>Entity Framework Core,entity-framework-core,EF,Data,O/RM</tags>
     <serviceable>true</serviceable>
-    <dependencies>
-      <group targetFramework=".NETStandard1.3">
-        <!-- this is only a "dependency" to make installing easier. It's not actaully build against this assembly. -->
-        <dependency id="Microsoft.EntityFrameworkCore.Design" version="$efcoredesign$" />
-      </group>
-      <group targetFramework=".NETFramework4.5.1">
-        <!-- this is only a "dependency" to make installing easier. It's not actaully build against this assembly. -->
-        <dependency id="Microsoft.EntityFrameworkCore.Design" version="$efcoredesign$" />
-      </group>
-    </dependencies>
   </metadata>
   <files>
     <file src="lib/**/*" target="" />

--- a/src/Microsoft.EntityFrameworkCore.Tools/project.json
+++ b/src/Microsoft.EntityFrameworkCore.Tools/project.json
@@ -14,10 +14,6 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "Microsoft.EntityFrameworkCore.Design": {
-      "version": "1.0.1",
-      "type": "build"
-    },
     "Microsoft.PowerShell.3.ReferenceAssemblies": {
       "type": "build",
       "version": "1.0.0"

--- a/src/ef/Properties/ToolsStrings.Designer.cs
+++ b/src/ef/Properties/ToolsStrings.Designer.cs
@@ -69,7 +69,7 @@ namespace Tools.Console.Properties {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Cannot execute this command because Microsoft.EntityFrameworkCore.Design is not installed..
+        ///    Looks up a localized string similar to Cannot execute this command because Microsoft.EntityFrameworkCore.Design is not installed. Install the version of that package that matches the installed version of Microsoft.EntityFrameworkCore and try again..
         /// </summary>
         public static string DesignDependencyNotFound {
             get {

--- a/src/ef/Properties/ToolsStrings.resx
+++ b/src/ef/Properties/ToolsStrings.resx
@@ -121,6 +121,6 @@
     <value>Cannot execute this command because the version of Microsoft.EntityFrameworkCore.Design installed is not compatible with this tool.</value>
   </data>
   <data name="DesignDependencyNotFound" xml:space="preserve">
-    <value>Cannot execute this command because Microsoft.EntityFrameworkCore.Design is not installed.</value>
+    <value>Cannot execute this command because Microsoft.EntityFrameworkCore.Design is not installed. Install the version of that package that matches the installed version of Microsoft.EntityFrameworkCore and try again.</value>
   </data>
 </root>

--- a/tools/CommandsPackager/CommandPackager.cs
+++ b/tools/CommandsPackager/CommandPackager.cs
@@ -34,7 +34,6 @@ namespace CommandPackager
         {
             var project = ProjectContext.Create(Path.Combine(_baseDir, "src", "Microsoft.EntityFrameworkCore.Tools"), FrameworkConstants.CommonFrameworks.Net451);
             var props = "configuration=" + _config;
-            props += ";efcoredesign=" + GetLockFileVersion(project, "Microsoft.EntityFrameworkCore.Design");
 
             var version = project.ProjectFile.Version.ToNormalizedString();
             await Nuget("pack",


### PR DESCRIPTION
Since this version works with both version 1.0 and 1.1 of EF, this dependency does more harm than good. If Microsoft.EntityFrameworkCore.Design isn't installed, you'll get the following error:

> Cannot execute this command because Microsoft.EntityFrameworkCore.Design is not installed.

Afterwhich you should install the version that matches your runtime.
