### PR TITLE
CLI: Work with MSBuild projects

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Tools.DotNet/CommandLineOptions.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.DotNet/CommandLineOptions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.DotNet
             var app = new CommandLineApplication(throwOnUnexpectedArg: false)
             {
                 Name = "dotnet ef",
-                FullName = "Entity Framework .NET Core CLI Commands"
+                FullName = "Entity Framework Core .NET Command Line Tools"
             };
 
             var options = new CommandLineOptions();
@@ -44,10 +44,10 @@ namespace Microsoft.EntityFrameworkCore.Tools.DotNet
         {
             var project = app.Option(
                 "-p|--project <project>",
-                "The project to target (defaults to the project in the current directory). Can be a path to a project.json or a project directory.");
+                "The project to target (defaults to the project in the current directory).");
             var startupProject = app.Option(
                 "-s|--startup-project <project>",
-                "The path to the project containing Startup (defaults to the target project). Can be a path to a project.json or a project directory.");
+                "The path to the project containing Startup (defaults to the target project).");
             var configuration = app.Option(
                 "--configuration <configuration>",
                 $"Configuration under which to load (defaults to {Constants.DefaultConfiguration})");

--- a/src/Microsoft.EntityFrameworkCore.Tools.DotNet/Internal/DotNetProjectContext.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.DotNet/Internal/DotNetProjectContext.cs
@@ -41,7 +41,6 @@ namespace Microsoft.EntityFrameworkCore.Tools.DotNet.Internal
                 ? _paths.RuntimeFiles.Executable
                 : _paths.RuntimeFiles.Assembly;
 
-        public Project Project => _project.ProjectFile;
         public string ProjectFullPath => _project.ProjectFile.ProjectFilePath;
         public string ProjectName => _project.ProjectFile.Name;
         public string RootNamespace => _project.ProjectFile.Name;

--- a/src/Microsoft.EntityFrameworkCore.Tools.DotNet/Internal/MsBuildProjectContext.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.DotNet/Internal/MsBuildProjectContext.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.DotNet.Cli.Utils;
+using NuGet.Frameworks;
+
+namespace Microsoft.EntityFrameworkCore.Tools.DotNet.Internal
+{
+    public class MsBuildProjectContext : IProjectContext
+    {
+        public MsBuildProjectContext(string filePath, NuGetFramework framework, string configuration, string outputDir)
+        {
+            var metadata = GetProjectMetadata(filePath, framework, configuration, outputDir);
+
+            Configuration = configuration;
+            ProjectName = Path.GetFileNameWithoutExtension(filePath);
+            ProjectFullPath = metadata["ProjectPath"];
+            RootNamespace = metadata["RootNamespace"] ?? ProjectName;
+            TargetFramework = NuGetFramework.Parse(metadata["NuGetTargetMoniker"]);
+            IsClassLibrary = string.Equals(metadata["OutputType"], "Library", StringComparison.OrdinalIgnoreCase);
+            TargetDirectory = metadata["TargetDir"];
+            Platform = metadata["Platform"];
+            AssemblyFullPath = metadata["TargetPath"];
+            PackagesDirectory = metadata["NuGetPackageRoot"];
+
+            // TODO get from actual properties according to TFM
+            Config = AssemblyFullPath + ".config";
+            RuntimeConfigJson = Path.Combine(TargetDirectory, Path.GetFileNameWithoutExtension(AssemblyFullPath) + ".runtimeconfig.json");
+            DepsJson = Path.Combine(TargetDirectory, Path.GetFileNameWithoutExtension(AssemblyFullPath) + ".deps.json");
+        }
+
+        public NuGetFramework TargetFramework { get; }
+        public bool IsClassLibrary { get; }
+        public string Config { get; }
+        public string DepsJson { get; }
+        public string RuntimeConfigJson { get; }
+        public string PackagesDirectory { get; }
+        public string AssemblyFullPath { get; }
+        public string ProjectName { get; }
+        public string Configuration { get; }
+        public string Platform { get; }
+        public string ProjectFullPath { get; }
+        public string RootNamespace { get; }
+        public string TargetDirectory { get; }
+
+        private IReadOnlyDictionary<string, string> GetProjectMetadata(string filePath, NuGetFramework framework, string configuration, string outputDir)
+        {
+            var metadataFile = Path.GetTempFileName();
+            try
+            {
+                var args = new List<string>
+                {
+                    "/t:_EFGetProjectMetadata",
+                    "/p:Configuration=" + configuration,
+                    "/p:_EFProjectMetadataFile=" + metadataFile
+                };
+
+                if (outputDir != null)
+                {
+                    args.Add("/p:OutputPath=" + outputDir);
+                }
+
+                if (framework != null)
+                {
+                    args.Add("/p:TargetFramework=" + framework.GetShortFolderName());
+                }
+
+                var command = Command.CreateDotNet("msbuild", args);
+                var result = command.Execute();
+                if (result.ExitCode != 0)
+                {
+                    throw new OperationErrorException(
+                        $"Couldn't read metadata for project '{filePath}'. Ensure the package 'Microsoft.EntityFrameworkCore.Tools' is installed.");
+                }
+
+                return File.ReadLines(metadataFile).Select(l => l.Split(new[] { ':' }, 2))
+                    .ToDictionary(s => s[0], s => s[1].TrimStart());
+            }
+            finally
+            {
+                File.Delete(metadataFile);
+            }
+        }
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.Tools.DotNet/Internal/ProjectContextFactory.cs
+++ b/src/Microsoft.EntityFrameworkCore.Tools.DotNet/Internal/ProjectContextFactory.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.InternalAbstractions;
@@ -14,8 +16,41 @@ namespace Microsoft.EntityFrameworkCore.Tools.DotNet.Internal
     {
         public IProjectContext Create(string filePath,
             NuGetFramework framework,
-            string configuration = null,
-            string outputDir = null)
+            string configuration,
+            string outputDir)
+        {
+            configuration = configuration ?? Constants.DefaultConfiguration;
+
+            if (Directory.Exists(filePath))
+            {
+                var msbuildFiles = Directory.EnumerateFiles(filePath, "*.*proj")
+                    .Where(f => !string.Equals(Path.GetExtension(f), ".xproj", StringComparison.OrdinalIgnoreCase))
+                    .Take(2).ToList();
+                if (msbuildFiles.Count == 2)
+                {
+                    throw new OperationErrorException($"Multiple projects found in the directory '{filePath}'");
+                }
+                if (msbuildFiles.Count == 1)
+                {
+                    return CreateMsBuildContext(msbuildFiles[0], framework, configuration, outputDir);
+                }
+
+                return CreateDotNetContext(filePath, framework, configuration, outputDir);
+            }
+
+            if (!Path.GetFileName(filePath).Equals("project.json", StringComparison.OrdinalIgnoreCase))
+            {
+                return CreateMsBuildContext(filePath, framework, configuration, outputDir);
+            }
+
+            return CreateDotNetContext(filePath, framework, configuration, outputDir);
+        }
+
+        private IProjectContext CreateDotNetContext(
+            string filePath,
+            NuGetFramework framework,
+            string configuration,
+            string outputDir)
         {
             var project = SelectCompatibleFramework(
                 framework,
@@ -23,9 +58,16 @@ namespace Microsoft.EntityFrameworkCore.Tools.DotNet.Internal
                     runtimeIdentifiers: RuntimeEnvironmentRidExtensions.GetAllCandidateRuntimeIdentifiers()));
 
             return new DotNetProjectContext(project,
-                configuration ?? Constants.DefaultConfiguration,
+                configuration,
                 outputDir);
         }
+
+        private IProjectContext CreateMsBuildContext(
+            string filePath,
+            NuGetFramework framework,
+            string configuration,
+            string outputDir)
+            => new MsBuildProjectContext(filePath, framework, configuration, outputDir);
 
         private ProjectContext SelectCompatibleFramework(NuGetFramework target, IEnumerable<ProjectContext> contexts)
             => NuGetFrameworkUtility.GetNearest(contexts, target ?? FrameworkConstants.CommonFrameworks.NetCoreApp10, f => f.TargetFramework)

--- a/src/Microsoft.EntityFrameworkCore.Tools/Microsoft.EntityFrameworkCore.Tools.nuspec
+++ b/src/Microsoft.EntityFrameworkCore.Tools/Microsoft.EntityFrameworkCore.Tools.nuspec
@@ -12,6 +12,8 @@
     <serviceable>true</serviceable>
   </metadata>
   <files>
+    <file src="build/**/*" target="" />
+    <file src="buildCrossTargeting/**/*" target="" />
     <file src="lib/**/*" target="" />
     <file src="bin/$configuration$/net451/Microsoft.EntityFrameworkCore.Tools.dll" target="tools/" />
     <file src="tools/**/*" target=""/>

--- a/src/Microsoft.EntityFrameworkCore.Tools/build/Microsoft.EntityFrameworkCore.Tools.targets
+++ b/src/Microsoft.EntityFrameworkCore.Tools/build/Microsoft.EntityFrameworkCore.Tools.targets
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="_EFGetProjectMetadata">
+    <ItemGroup>
+      <_EFProjectMetadata Include="NuGetPackageRoot: $(NuGetPackageRoot)" />
+      <_EFProjectMetadata Include="NuGetTargetMoniker: $(NuGetTargetMoniker)" />
+      <_EFProjectMetadata Include="OutputType: $(OutputType)" />
+      <_EFProjectMetadata Include="Platform: $(Platform)" />
+      <_EFProjectMetadata Include="ProjectPath: $(ProjectPath)" />
+      <_EFProjectMetadata Include="RootNamespace: $(RootNamespace)" />
+      <_EFProjectMetadata Include="TargetDir: $(TargetDir)" />
+      <_EFProjectMetadata Include="TargetPath: $(TargetPath)" />
+    </ItemGroup>
+    <WriteLinesToFile File="$(_EFProjectMetadataFile)" Lines="@(_EFProjectMetadata)" />
+  </Target>
+</Project>

--- a/src/Microsoft.EntityFrameworkCore.Tools/buildCrossTargeting/Microsoft.EntityFrameworkCore.Tools.targets
+++ b/src/Microsoft.EntityFrameworkCore.Tools/buildCrossTargeting/Microsoft.EntityFrameworkCore.Tools.targets
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="_EFGetProjectMetadata">
+    <MSBuild Projects="$(MSBuildProjectFile)"
+             Targets="_EFGetProjectMetadata"
+             Properties="TargetFramework=$(TargetFrameworks.Split(';')[0]);_EFProjectMetadataFile=$(_EFProjectMetadataFile)" />
+  </Target>
+</Project>

--- a/src/Microsoft.EntityFrameworkCore.Tools/tools/EntityFrameworkCore.psm1
+++ b/src/Microsoft.EntityFrameworkCore.Tools/tools/EntityFrameworkCore.psm1
@@ -930,7 +930,7 @@ function GetProjectItem($project, $path) {
     return $null
 }
 
-function GetStartUpProject($name, $fallbackProject) {
+function GetStartupProject($name, $fallbackProject) {
     if ($name) {
         return Get-Project $name
     }

--- a/src/ef/CommandLineOptions.cs
+++ b/src/ef/CommandLineOptions.cs
@@ -30,11 +30,11 @@ namespace Microsoft.EntityFrameworkCore.Tools
             var app = new CommandLineApplication
             {
 #if NET451
-                Name = "ef.exe",
+                Name = "ef",
 #else
-                Name = "ef.dll",
+                Name = "ef",
 #endif
-                FullName = "Entity Framework Core Console Commands"
+                FullName = "Entity Framework Core Command Line Tools"
             };
 
             app.HelpOption();

--- a/test/ef.FunctionalTests/project.json
+++ b/test/ef.FunctionalTests/project.json
@@ -15,6 +15,10 @@
   },
   "testRunner": "xunit",
   "frameworks": {
-    "net451": {}
+    "net451": {
+      "frameworkAssemblies": {
+        "System.Text.Encoding": "4.0.0.0"
+      }
+    }
   }
 }

--- a/tools/CommandsPackager/CommandPackager.cs
+++ b/tools/CommandsPackager/CommandPackager.cs
@@ -41,7 +41,8 @@ namespace CommandPackager
                 "-Verbosity", "detailed",
                 "-OutputDirectory", Path.Combine(_baseDir, "artifacts/build"),
                 "-Version", version,
-                "-Properties", props);
+                "-Properties", props,
+                "-NoPackageAnalysis");
         }
 
         private async Task PackToolsDotNet()
@@ -57,7 +58,8 @@ namespace CommandPackager
                 "-Verbosity", "detailed",
                 "-OutputDirectory", Path.Combine(_baseDir, "artifacts/build"),
                 "-Version", version,
-                "-Properties", props);
+                "-Properties", props,
+                "-NoPackageAnalysis");
         }
 
         private static string GetLockFileVersion(ProjectContext project, string name) =>


### PR DESCRIPTION
Resolves aspnet/EntityFramework#6139

This is based on [the prototype](https://github.com/aspnet/EntityFramework/compare/feature/msbuild) by @natemcmaster.
### TODO
- [ ] Add tests (`dotnet restore3` had some issues with stars in versions)
- [ ] React to CLI changes
  - Color isn't flowing through
  - There's lot of output coming from from MSBuild
- [ ] Ensure NuGet commands work with VS "15" csproj
- [ ] ~~Remove `project.json` support~~ (not yet)

cc @Eilon
