### PR TITLE
Run e2e tests in tmp dir

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Tools.DotNet/project.json
+++ b/src/Microsoft.EntityFrameworkCore.Tools.DotNet/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "1.0.0-*",
+  "version": "1.0.0-msbuild2-final",
   "description": "Entity Framework Core .NET Command Line Tools. Includes dotnet-ef.",
   "buildOptions": {
     "emitEntryPoint": true,

--- a/src/Microsoft.EntityFrameworkCore.Tools/project.json
+++ b/src/Microsoft.EntityFrameworkCore.Tools/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-*",
+  "version": "1.0.0-msbuild2-final",
   "description": "Entity Framework Core Package Manager Console Tools. Includes Scaffold-DbContext, Add-Migration, and Update-Database.",
   "packOptions": {
     "tags": [

--- a/test/Microsoft.EntityFrameworkCore.Tools.DotNet.FunctionalTests/DotNetEfFixture.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tools.DotNet.FunctionalTests/DotNetEfFixture.cs
@@ -5,19 +5,39 @@ using System;
 using System.IO;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.EntityFrameworkCore.Tools.DotNet.FunctionalTests.Utilities;
+using Microsoft.EntityFrameworkCore.Tools.DotNet.TestUtilities;
 
 namespace Microsoft.EntityFrameworkCore.Tools.DotNet.FunctionalTests
 {
     public class DotNetEfFixture : IDisposable
     {
-        public string TestProjectRoot { get; } = Path.Combine(AppContext.BaseDirectory, "TestProjects");
+        public string TestProjectRoot { get; } = Path.Combine(Path.GetTempPath(), "ef.tools.tests", Guid.NewGuid().ToString("N"));
+
+        private readonly string _testProjectsSource = Path.Combine(AppContext.BaseDirectory, "TestProjects");
 
         public DotNetEfFixture()
         {
+            Directory.CreateDirectory(TestProjectRoot);
+            FileUtility.DirectoryCopy(_testProjectsSource, TestProjectRoot, recursive: true);
+
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir.Parent != null)
+            {
+                var nugetConfig = Path.Combine(dir.FullName, "NuGet.config");
+                if (File.Exists(nugetConfig))
+                {
+                    File.Copy(nugetConfig, Path.Combine(TestProjectRoot, "NuGet.config"));
+                    break;
+                }
+                dir = dir.Parent;
+            }
+
             foreach (var file in Directory.EnumerateFiles(TestProjectRoot, "project.json.ignore", SearchOption.AllDirectories))
             {
                 File.Move(file, Path.Combine(Path.GetDirectoryName(file), "project.json"));
             }
+
+            Console.WriteLine($"Fixture work dir = {TestProjectRoot}".Bold().Black());
             Console.WriteLine("Restoring test projects...".Bold().Black());
             AssertCommand.Pass(new DotnetRestore(TestProjectRoot, null).Execute());
             Console.WriteLine("Restore done.".Bold().Black());
@@ -25,10 +45,14 @@ namespace Microsoft.EntityFrameworkCore.Tools.DotNet.FunctionalTests
 
         public void Dispose()
         {
-            // cleanup to prevent later errors with restore
-            foreach (var file in Directory.EnumerateFiles(TestProjectRoot, "project.json", SearchOption.AllDirectories))
+            try
             {
-                File.Move(file, Path.Combine(Path.GetDirectoryName(file), "project.json.ignore"));
+                Directory.Delete(TestProjectRoot, recursive: true);
+            }
+            catch
+            {
+                Console.Error.WriteLine("Failed to delete " + TestProjectRoot);
+                throw;
             }
         }
     }

--- a/test/Microsoft.EntityFrameworkCore.Tools.DotNet.FunctionalTests/EndToEndTests.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tools.DotNet.FunctionalTests/EndToEndTests.cs
@@ -29,6 +29,10 @@ namespace Microsoft.EntityFrameworkCore.Tools.DotNet.FunctionalTests
 
             var result = new AddMigration(targetProject, "Initial", _output)
                .ExecuteWithCapturedOutput();
+
+            _output.WriteLine(result.StdOut);
+            _output.WriteLine(result.StdErr);
+
             AssertCommand.Fail(result);
             Assert.Contains(ToolsStrings.DesignDependencyNotFound, result.StdErr);
         }

--- a/test/Microsoft.EntityFrameworkCore.Tools.DotNet.FunctionalTests/TestUtilities/FileUtility.cs
+++ b/test/Microsoft.EntityFrameworkCore.Tools.DotNet.FunctionalTests/TestUtilities/FileUtility.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+
+namespace Microsoft.EntityFrameworkCore.Tools.DotNet.TestUtilities
+{
+    public class FileUtility
+    {
+        public static void DirectoryCopy(string source, string dest, bool recursive)
+        {
+            var dir = new DirectoryInfo(source);
+
+            if (!dir.Exists)
+            {
+                throw new DirectoryNotFoundException(
+                    "Source directory does not exist or could not be found: "
+                    + source);
+            }
+
+            var dirs = dir.GetDirectories();
+            if (!Directory.Exists(dest))
+            {
+                Directory.CreateDirectory(dest);
+            }
+
+            var files = dir.GetFiles();
+            foreach (var file in files)
+            {
+                var temppath = Path.Combine(dest, file.Name);
+                file.CopyTo(temppath, false);
+            }
+
+            if (recursive)
+            {
+                foreach (DirectoryInfo subdir in dirs)
+                {
+                    var temppath = Path.Combine(dest, subdir.Name);
+                    DirectoryCopy(subdir.FullName, temppath, recursive);
+                }
+            }
+        }
+    }
+}

--- a/test/ef.FunctionalTests/TestUtilities/TempDirectory.cs
+++ b/test/ef.FunctionalTests/TestUtilities/TempDirectory.cs
@@ -18,6 +18,16 @@ namespace Microsoft.EntityFrameworkCore.Design.TestUtilities
         public string Path { get; }
 
         public void Dispose()
-            => Directory.Delete(Path, recursive: true);
+        {
+            try
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+            catch
+            {
+                Console.Error.WriteLine("Failed to delete " + Path);
+                throw;
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes tests in CI environments. They were failing due to max path length restrictions.

cc @bricelam 